### PR TITLE
Prefer variables to prompt users for input

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -1,7 +1,7 @@
 data "aws_vpc" "selected" {
   filter {
     name   = "tag:Name"
-    values = ["shared-vpc"]
+    values = [var.vpc_name]
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 locals {
-  name_prefix = "" # provide your name prefix
+  name_prefix = var.name_prefix
 }
 
 module "web_app" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,11 @@
+# terraform apply -var="name_prefix=your-name" -var="vpc_name=your-vpc-name"
+
+variable "name_prefix" {
+  description = "Your name prefix to label all resources"
+  type        = string
+}
+
+variable "vpc_name" {
+  description = "An existing VPC to use"
+  type        = string
+}


### PR DESCRIPTION
Use variables so that running `terraform apply` will prompt for inputs of `name_prefix` and `vpc_name`.