### PR TITLE
Make region a required variable and other superficial changes.

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = ">= 5.73.0"
   hashes = [
     "h1:FbznG2p+5b90nFIQxlFg1601ZvcfoR+V9WDFF7abhdo=",
+    "h1:YoOBDt9gdoivbUh1iGoZNqRBUdBO+PBAxpSZFeTLLYE=",
     "zh:05534adf6f02d6ec26dbeb37a4d2b6edb63f12dc9ab5cc05ab89329fcd793194",
     "zh:1d224056866abc4c8f893d55bc6493b73688126fbeaf017ecfbcf5d2f16649c4",
     "zh:486d28a0a4af2ea23964a8e9087d66e8d794e3438976633b8554684a9237499d",
@@ -28,6 +29,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version = "3.6.3"
   hashes = [
     "h1:f6jXn4MCv67kgcofx9D49qx1ZEBv8oyvwKDMPBr0A24=",
+    "h1:zG9uFP8l9u+yGZZvi5Te7PV62j50azpgwPunq2vTm1E=",
     "zh:04ceb65210251339f07cd4611885d242cd4d0c7306e86dda9785396807c00451",
     "zh:448f56199f3e99ff75d5c0afacae867ee795e4dfda6cb5f8e3b2a72ec3583dd8",
     "zh:4b4c11ccfba7319e901df2dac836b1ae8f12185e37249e8d870ee10bb87a13fe",

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ terrafrom apply
 Alternatively, you may pass in the values directly by adding the `-var` flag.
 
 ```sh
-terraform apply -var="name_prefix=your-name" -var="vpc_name=your-vpc-name"
+terraform apply -var="name_prefix=your-name" -var="vpc_name=your-vpc-name -var="aws_region=ap-southeast-1"
 ```
 
 Another way is to include a `values.tfvars` and then use the `-var-file` flag.
@@ -23,6 +23,7 @@ Another way is to include a `values.tfvars` and then use the `-var-file` flag.
 ```hcl
 name_prefix = "your-name"
 vpc_name = "your-vpc"
+aws_region = "ap-southeast-1"
 ```
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# tf-ec2-alb
+
+Initialize Terraform.
+
+```sh
+terraform init
+```
+
+Apply the configuration. You will be prompted to add the values for the variables.
+
+```sh
+terrafrom apply
+```
+
+Alternatively, you may pass in the values directly by adding the `-var` flag.
+
+```sh
+terraform apply -var="name_prefix=your-name" -var="vpc_name=your-vpc-name"
+```
+
+Another way is to include a `values.tfvars` and then use the `-var-file` flag.
+
+```hcl
+name_prefix = "your-name"
+vpc_name = "your-vpc"
+```
+
+```sh
+terrafrom apply -var-file="values.tfvars"
+```

--- a/data.tf
+++ b/data.tf
@@ -26,3 +26,7 @@ data "aws_subnets" "private" {
     values = ["*private*"]
   }
 }
+
+data "aws_ec2_instance_type" "selected" {
+  instance_type = var.instance_type
+}

--- a/main.tf
+++ b/main.tf
@@ -5,13 +5,12 @@ locals {
 module "web_app" {
   source = "./modules/web_app"
 
-  name_prefix = local.name_prefix
-
-  instance_type = "t2.micro"
+  name_prefix   = local.name_prefix
+  instance_type = var.instance_type
+  file_content  = var.file_content
 
   vpc_id            = data.aws_vpc.selected.id
   public_subnet_ids = data.aws_subnets.public.ids
-
 }
 
 module "alb" {

--- a/modules/web_app/data.tf
+++ b/modules/web_app/data.tf
@@ -1,0 +1,9 @@
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-2023*-x86_64"]
+  }
+}

--- a/modules/web_app/main.tf
+++ b/modules/web_app/main.tf
@@ -7,7 +7,7 @@ resource "random_integer" "subnet_id_selection" {
 }
 
 resource "aws_instance" "webapp" {
-  ami                    = "ami-04c913012f8977029"
+  ami                    = data.aws_ami.amazon_linux.id
   instance_type          = var.instance_type
   subnet_id              = var.public_subnet_ids[random_integer.subnet_id_selection.result]
   vpc_security_group_ids = [aws_security_group.webapp.id]

--- a/modules/web_app/main.tf
+++ b/modules/web_app/main.tf
@@ -12,7 +12,7 @@ resource "aws_instance" "webapp" {
   subnet_id              = var.public_subnet_ids[random_integer.subnet_id_selection.result]
   vpc_security_group_ids = [aws_security_group.webapp.id]
   user_data = templatefile("${path.module}/init-script.sh", {
-    file_content = "webapp"
+    file_content = var.file_content
   })
 
   associate_public_ip_address = true

--- a/modules/web_app/variables.tf
+++ b/modules/web_app/variables.tf
@@ -6,7 +6,7 @@ variable "name_prefix" {
 variable "instance_type" {
   description = "Instance type of ec2"
   type        = string
-  default     = "t2.micro"
+  default     = "t3.micro"
 }
 
 variable "vpc_id" {
@@ -17,4 +17,10 @@ variable "vpc_id" {
 variable "public_subnet_ids" {
   description = "Public subnet ids"
   type        = list(string)
+}
+
+variable "file_content" {
+  description = "File content of user data"
+  type        = string
+  default = "webapp"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,7 @@
 output "application_http_url" {
   value = "http://${module.alb.dns_name}"
 }
+
+output "instance_type" {
+  value = "The instance type ${data.aws_ec2_instance_type.selected.instance_type} is ${data.aws_ec2_instance_type.selected.free_tier_eligible ? "" : "not "}free tier eligible."
+}

--- a/provider.tf
+++ b/provider.tf
@@ -1,3 +1,4 @@
 provider "aws" {
-  region = "ap-southeast-1"
+  region  = var.aws_region
+  profile = var.aws_profile
 }

--- a/variables.tf
+++ b/variables.tf
@@ -6,6 +6,30 @@ variable "name_prefix" {
 }
 
 variable "vpc_name" {
-  description = "An existing VPC to use"
+  description = "An existing VPC with a public subnet"
   type        = string
+}
+
+variable "aws_profile" {
+  description = "AWS CLI profile to use for Terraform configuration"
+  type        = string
+  default     = "default"
+}
+
+variable "aws_region" {
+  description = "AWS region to create resources in"
+  type        = string
+  default     = "ap-southeast-1"
+}
+
+variable "file_content" {
+  description = "Content passed to the instance user data script."
+  type        = string
+  default     = "<h1>Welcome to My Web App</h1>"
+}
+
+variable "instance_type" {
+  description = "The instance type for the EC2 instance"
+  type        = string
+  default     = "t3.micro"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,4 @@
-# terraform apply -var="name_prefix=your-name" -var="vpc_name=your-vpc-name"
+# terraform apply -var="name_prefix=your-name" -var="vpc_name=your-vpc-name" -var="aws_region=ap-southeast-1"
 
 variable "name_prefix" {
   description = "Your name prefix to label all resources"
@@ -10,16 +10,20 @@ variable "vpc_name" {
   type        = string
 }
 
+variable "aws_region" {
+  description = "AWS region to create resources in"
+  type        = string
+
+  validation {
+    condition     = contains(["us-east-1", "ap-southeast-1"], var.aws_region)
+    error_message = "Invalid AWS region. Allowed values are: us-east-1, ap-southeast-1."
+  }
+}
+
 variable "aws_profile" {
   description = "AWS CLI profile to use for Terraform configuration"
   type        = string
   default     = "default"
-}
-
-variable "aws_region" {
-  description = "AWS region to create resources in"
-  type        = string
-  default     = "ap-southeast-1"
 }
 
 variable "file_content" {


### PR DESCRIPTION
The most significant change is to require region be specified so that any cohort is able to use the configuration. Validation is also set so that regions are either `ap-southeast-1` or `us-east-1`.

Other superficial changes: 
- Add custom file content for web app so students can add their own text.
- Updated the instance type to t3.micro (free tier eligible).
- Added a README for instructions for students.
- Use latest Amazon Linux AMI.